### PR TITLE
http: add missing header

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -20,6 +20,7 @@
 #include <sys/stat.h>
 #include <signal.h>
 #include <future>
+#include <deque>
 
 #include <event2/event.h>
 #include <event2/http.h>


### PR DESCRIPTION
httpserver.cpp:71:10: error: ‘deque’ in namespace ‘std’ does not name a template type
   71 |     std::deque<std::unique_ptr<WorkItem>> queue;
      |          ^~~~~